### PR TITLE
argon2 2.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>de.mkammerer</groupId>
 			<artifactId>argon2-jvm</artifactId>
-			<version>2.5</version>
+			<version>2.11</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
los metodos argon2.verify() y argon2.hash() estan obsoletos y piden otro tipo de parametros que se implementan en el controller y auth