### PR TITLE
 argon2.verify() y argon2.hash() estan obsoletos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,14 +58,14 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.19</version>
+			<version>8.0.30</version>
 			<scope>runtime</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>de.mkammerer</groupId>
 			<artifactId>argon2-jvm</artifactId>
-			<version>2.5</version>
+			<version>2.11</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
 			<artifactId>jjwt</artifactId>
 			<version>0.9.1</version>
 		</dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.1</version>
+		</dependency>
 
 	</dependencies>
 

--- a/src/main/java/com/cursojava/curso/controllers/UsuarioController.java
+++ b/src/main/java/com/cursojava/curso/controllers/UsuarioController.java
@@ -8,7 +8,6 @@ import de.mkammerer.argon2.Argon2Factory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @RestController

--- a/src/main/java/com/cursojava/curso/controllers/UsuarioController.java
+++ b/src/main/java/com/cursojava/curso/controllers/UsuarioController.java
@@ -36,7 +36,7 @@ public class UsuarioController {
     public void registrarUsuario(@RequestBody Usuario usuario) {
 
         Argon2 argon2 = Argon2Factory.create(Argon2Factory.Argon2Types.ARGON2id);
-        String hash = argon2.hash(1, 1024, 1, usuario.getPassword());
+        String hash = argon2.hash(1, 1024, 1, usuario.getPassword().toCharArray());
         usuario.setPassword(hash);
 
         usuarioDao.registrar(usuario);

--- a/src/main/java/com/cursojava/curso/dao/UsuarioDaoImp.java
+++ b/src/main/java/com/cursojava/curso/dao/UsuarioDaoImp.java
@@ -49,7 +49,7 @@ public class UsuarioDaoImp implements UsuarioDao {
         String passwordHashed = lista.get(0).getPassword();
 
         Argon2 argon2 = Argon2Factory.create(Argon2Factory.Argon2Types.ARGON2id);
-        if (argon2.verify(passwordHashed, usuario.getPassword())) {
+        if (argon2.verify(passwordHashed, usuario.getPassword().toCharArray())) {
             return lista.get(0);
         }
         return null;


### PR DESCRIPTION
los metodos argon2.verify() y argon2.hash() estan obsoletos y piden otro tipo char[] en el ultimo parametro 